### PR TITLE
(backend)#46 login und weiterleitung

### DIFF
--- a/src/Backend/.env
+++ b/src/Backend/.env
@@ -5,3 +5,6 @@ password=MAIL_PASSWORT
 # JWT + Datenbank
 JWT_SECRET=<ein_langes_random_secret>
 DATABASE_URL=postgresql+psycopg2://<user>:<pass>@<host>:<port>/<dbname>
+
+# redirect verify
+FRONTEND_URL=http://localhost:5173

--- a/src/Backend/requirements.txt
+++ b/src/Backend/requirements.txt
@@ -8,6 +8,7 @@ passlib[bcrypt]==1.7.4
 python-jose[cryptography]==3.5.0
 python-multipart==0.0.20
 email-validator==2.3.0
+psycopg2-binary
 
 python-dotenv==1.2.1
 


### PR DESCRIPTION
In diesem PR habe ich zwei Backend-Anpassungen vorgenommen, die direkt zum Login-/Registrierungsprozess gehören.

## 1. Token-Laufzeit (Session) überarbeitet

Das Login-Token ist bisher nach 120 Minuten automatisch abgelaufen.  
Ich habe `create_access_token()` erweitert, sodass die Laufzeit optional übergeben werden kann.

- Login-Token laufen jetzt nicht mehr kurzfristig ab.
- Das Verifizierungs-Token (per Mail) hat weiterhin eine eigene Ablaufzeit (24h).

Damit bleibt der Nutzer eingeloggt, solange das Frontend das Token speichert (Logout , Tab schließen was auch immer).

## 2. Verifizierungs-Flow auf Redirect umgestellt

Der alte Code hat beim Öffnen des Links aus der Mail statisches HTML aus dem Backend angezeigt.  

Ich habe den Endpoint umgestellt:

- Token wird geprüft wie bisher  
- Benutzer wird aktiviert  
- Danach gibt es einen Redirect auf die Login-Seite des Frontends
- Fehlerfälle geben ebenfalls Redirects zurück

Damit funktioniert die Registrierung + Aktivierung nun als zusammenhängender Flow über das Frontend.

## Getestet

- Registrierung -> Mail-Link -> Redirect -> Aktivierung -> Login  
- Fehlerfälle (ungültiger Token, fehlender Benutzer) geben korrekte Redirects zurück  
- Login & Zugriff auf geschützte Routen funktionieren weiterhin

## Hinweise / Offene Punkte (nicht Teil dieses PRs)

### A) Hardcodiertes HTML in `sendmail.py`

Der Inhalt der Bestätigungsmail wird aktuell direkt in `sendmail.py` als HTML-String hardcodiert.  
Das funktioniert technisch, ist aber langfristig schwer wartbar und nicht flexibel.. das sollte in mail/templates oder so ausgelagert werden